### PR TITLE
Enable bignumber support by default

### DIFF
--- a/sock_modules/mathematriculator.js
+++ b/sock_modules/mathematriculator.js
@@ -21,6 +21,10 @@ exports.commands = {
 
 exports.begin = function begin(_, config) {
     errors = config.errors;
+    math.config({
+        number: 'bignumber',
+        precision: 4096
+    });
 };
 
 function calc(payload, callback) {


### PR DESCRIPTION
Configure mathjs so it uses bignums by default (with a somewhat excessive precision).